### PR TITLE
More standard-compliant use of vector reserve() vs. resize() and push…

### DIFF
--- a/reduce_src/AtomPositions.cpp
+++ b/reduce_src/AtomPositions.cpp
@@ -871,13 +871,13 @@ int AtomPositions::SearchClique(std::list<MoverPtr> clique, int limit)
 	const int numItems = clique.size();
 	std::vector<MoverPtr>    item (numItems);
 	std::vector<double> currScore;
-	currScore.reserve(numItems);
+	currScore.resize(numItems);
 	std::vector<float>   currBump;
-	currBump.reserve(numItems);
+	currBump.resize(numItems);
 	std::vector<float>  currHbond;
-	currHbond.reserve(numItems);
+	currHbond.resize(numItems);
 	std::vector<bool> currBadBump;
-	currBadBump.reserve(numItems);
+	currBadBump.resize(numItems);
 	std::vector<std::list<AtomDescr> >   atomsInCliq( numItems );
 	std::vector<std::list<AtomDescr>* >   bmpingAtoms;
 	std::vector<std::list<AtomDescr > > bumpingNonBonded( numItems );

--- a/reduce_src/reduce.cpp
+++ b/reduce_src/reduce.cpp
@@ -1887,7 +1887,7 @@ void genHydrogens(const atomPlacementPlan& pp, ResBlk& theRes, bool o2prime,
 				std::list<PDBrec*> rs;
 				theRes.get(pp.conn(i), rs);
 				if (!rs.empty()) {
-					nconf[i] = rs.size();
+					nconf.push_back(rs.size());
 					maxalt = std::max(maxalt, nconf[i]);
 					std::vector<PDBrec*> rvv_v;
 					rvv_v.reserve(nconf[i]);


### PR DESCRIPTION
Handling vector resizing in a way that avoids triggering assertions in debug mode.